### PR TITLE
corrected date in license header

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ var license = license ||
     '! ' + pkgname +
     ' | ' + pkgversion +
     ' | ' + pkglicense +
-    ' | ' + date.getDay() +
-    '/' + date.getDate() +
+    ' | ' + date.getDate() +
+    '/' + (date.getMonth() + 1) +
     '/' + date.getFullYear() + ' ';
 
 /* PostCSS Plugins */


### PR DESCRIPTION
The license header always contains funky dates. This is because it's  using day number instead of Month number. The change above should provide a correct value for dd/mm/yyyy.